### PR TITLE
[Feature] Set cwd as user home

### DIFF
--- a/osia/cli.py
+++ b/osia/cli.py
@@ -18,6 +18,7 @@ openshift"""
 import argparse
 import logging
 from typing import List
+from os import environ, getcwd
 import coloredlogs
 
 from dynaconf import settings
@@ -176,6 +177,8 @@ def _create_commons():
                                     required=False, default='installers')],
         [['--skip-git'], dict(help='When set, the persistance will be skipped',
                               action='store_true')],
+        [['--orig-user-home'], dict(help='Forbid change of user home location',
+                                    action='store_true')],
         [['-v', '--verbose'], dict(help='Increase verbosity level', action='store_true')]
     ]
     for k in common_arguments:
@@ -214,5 +217,6 @@ def main_cli():
     else:
         coloredlogs.install(level='INFO')
     logging.captureWarnings(True)
-
+    if not vars(args).get('orig_user_home', False):
+        environ['HOME'] = getcwd()
     args.func(args)

--- a/osia/installer/executor.py
+++ b/osia/installer/executor.py
@@ -32,9 +32,8 @@ class InstallerExecutionException(Exception):
 
 def execute_installer(installer, base_path, operation, os_image=None):
     """Function executes actual installation of OpenShift"""
-    additional_env = None
+    additional_env = environ.copy()
     if os_image is not None and os_image:
-        additional_env = environ.copy()
         additional_env.update({'OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE': os_image})
     with Popen([installer, operation, 'cluster', '--dir', base_path],
                env=additional_env, universal_newlines=True) as proc:


### PR DESCRIPTION
This feature enables to store configuration files for clouds and DNS providers
into the root of working git repository like in user home, instead of preconfiguring
hosts used to deploy clusters.

The configuration is then expected to be in folders:
- .aws                          Aws credentials
- .config/openstack     where clouds.yaml will be stored
- .ovirt                         configuration for ovirt connection