### PR TITLE
Add support for specifying -4 option to nsupdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ default:
       zone: ''
       key_file: ''
       ttl: 0 
+      use_ipv4: false
 ```
 
 Every key here is overridible by the argument passed to the installer.

--- a/osia/cli.py
+++ b/osia/cli.py
@@ -72,7 +72,9 @@ ARGUMENTS = {
         'dns_ttl': {'help': 'TTL of the records', 'type': int},
         'dns_key_file': {'help': 'Keyfile used to access dns server via nsupdate'},
         'dns_zone': {'help': 'Zone on server where the record will be stored'},
-        'dns_server': {'help': 'Address of server with running bind'}
+        'dns_server': {'help': 'Address of server with running bind'},
+        'dns_use_ipv4': {'help': 'Use only IPv4 for DNS settings', 'action': 'store_const',
+                         'const': True}
     }
 }
 

--- a/osia/installer/dns/nsupdate.py
+++ b/osia/installer/dns/nsupdate.py
@@ -22,14 +22,18 @@ from osia.installer.clouds.base import AbstractInstaller
 
 class NSUpdate(DNSUtil):
     """Implementation of DNSUtil specific for nsupdate dns provider"""
-    def __init__(self, key_file=None, server=None, zone=None, **kwargs):
+    def __init__(self, key_file=None, server=None, zone=None, use_ipv4=False, **kwargs):
         super().__init__(**kwargs)
         self.key_file = key_file
         self.server = server
         self.zone = zone
+        self.use_ipv4 = use_ipv4
 
     def _exec_nsupdate(self, string: str):
-        with Popen(["nsupdate", "-k", self.key_file], stdin=PIPE, universal_newlines=True) as nsu:
+        nsupdate_args = ["nsupdate", "-k", self.key_file]
+        if self.use_ipv4:
+            nsupdate_args.append('-4')
+        with Popen(nsupdate_args, stdin=PIPE, universal_newlines=True) as nsu:
             nsu.communicate(string)
             self.modified = True
 


### PR DESCRIPTION
In our environment, our DNS server requires passing the "-4" argument to
the nsupdate command. This change adds support for configuring OSIA to
use this option when using the nsupdate dns provider.