### PR TITLE
Fix reference to cloud_env in README and config.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The configuration has following structure:
 default:
   cloud:
     openstack:
-      base_env: env1
+      cloud_env: env1
       environments:
       - name: env1
         base_domain: ''
@@ -67,7 +67,7 @@ default:
         osp_base_flavor: ''
         network_list: []
     aws:
-      base_env: default
+      cloud_env: default
       environments:
       - name: default
         base_domain: ''

--- a/osia/config/config.py
+++ b/osia/config/config.py
@@ -30,7 +30,7 @@ def _resolve_cloud_name(args: argparse.Namespace) -> Optional[Dict]:
         args.cloud_environment
     if default_env is None:
         logging.error("Couldn't resolve default environment")
-        raise Exception("Invalid environment setup, base_env is missing")
+        raise Exception("Invalid environment setup, cloud_env is missing")
     for env in defaults['CLOUD'][args.cloud]['environments']:
         if env['name'] == default_env:
             return env


### PR DESCRIPTION
The readme and error message in config.py have references to a config
option `base_env` for specifying the environment when one is not
specified on the command line. The config.py code, however, looks for a
config option called `cloud_env` (if I'm interpreting the code
correctly). This change updates the error message and README to use the
proper config option.