### PR TITLE
updating networkType to OVNKubernetes

### DIFF
--- a/osia/installer/templates/install-config-base.yaml.jinja2
+++ b/osia/installer/templates/install-config-base.yaml.jinja2
@@ -40,7 +40,7 @@ networking:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   machineCIDR: {% block networkIp %}{% endblock %}
-  networkType: OpenShiftSDN
+  networkType: OVNKubernetes
   serviceNetwork:
   - 172.30.0.0/16
 platform:{% block platform %}{% endblock %}


### PR DESCRIPTION
We have suddenly started getting error while provisioning openshift clusters using OSIA.
 ERROR failed to fetch Metadata: failed to load asset "Install Config": failed to create install config: invalid "install-config.yaml" file: networking.networkType: Invalid value: "OpenShiftSDN": networkType OpenShiftSDN is deprecated, please use OVNKubernetes

Hence updating the NetworkType to OVNKubernetes