### PR TITLE
Fix for platform.machine() == aarch64 on Linux

### DIFF
--- a/osia/installer/downloader/install.py
+++ b/osia/installer/downloader/install.py
@@ -43,7 +43,8 @@ EXTRACTION_RE = re.compile(r'.*Extracting tools for .*, may take up to a minute.
 def _current_platform():
     if platform.system() == "Linux" and platform.machine() == "x86_64":
         return "linux", "amd64"
-    if platform.system() == "Linux" and platform.machine() == "arm64":
+    if platform.system() == "Linux" and (
+            platform.machine() == "arm64" or platform.machine() == "aarch64"):
         return "linux", "arm64"
     if platform.system() == "Darwin" and platform.machine() == "arm64":
         return "mac", "arm64"


### PR DESCRIPTION
```shell
$ python -c 'import platform; print(platform.machine())'
aarch64
```
I'm not sure if in some cases it returns arm64, so I just left that
possibility there.