### PR TITLE
Fix _TemporaryFileWrapper annotation

### DIFF
--- a/osia/installer/downloader/image.py
+++ b/osia/installer/downloader/image.py
@@ -1,4 +1,6 @@
 """Module implements logic for rhcos image download"""
+from __future__ import annotations
+
 import gzip
 import json
 import logging

--- a/osia/installer/downloader/install.py
+++ b/osia/installer/downloader/install.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Module responsible for download of openshift-install binary"""
+from __future__ import annotations
+
 import logging
 import platform
 import re

--- a/osia/installer/downloader/utils.py
+++ b/osia/installer/downloader/utils.py
@@ -1,5 +1,7 @@
 """Module implements utilitary functions shared by download
 package"""
+from __future__ import annotations
+
 import logging
 from collections.abc import Callable
 from pathlib import Path


### PR DESCRIPTION
deffer evaluation of annotations for _TemporaryFileWrapper type

Use _PEP 649 – Deferred Evaluation Of Annotations Using Descriptors_ in
files where _TemporaryFileWrapper is used

execution of `osia install` results in:
  Traceback: `TypeError: type '_TemporaryFileWrapper' is not subscriptable`

Fixes: a023c78 ("Fix mypy errors in installer/downloader/install.py")
Fixes: dcb6c68 ("Fix mypy errors in installer/downloader/image.py")
Fixes: 4535238 ("Fix mypy error in installer/downloader/utils.py")
