### PR TITLE
allow to download corss-arch installer

### DIFF
--- a/osia/installer/downloader/install.py
+++ b/osia/installer/downloader/install.py
@@ -171,6 +171,10 @@ def download_installer(installer_version: str,
     if version:
         root = root.joinpath(version)
 
+    _, local_arch = _current_platform()
+    if installer_arch != local_arch:
+        root = root.joinpath(installer_arch)
+
     installer_exe_name = 'openshift-install'
 
     if fips:


### PR DESCRIPTION
if host architecture and target ocp architecture is same, keep installer in a `installers/4.x.y/openshift-install{,-fips}`, but if its different put it into `installers/4.x.y/arm64/openshift-install{,-fips}` for arm64.

Fixes: #105